### PR TITLE
found a small error in testing for `{type: 'array', uniqueItems: true}` ...

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -276,7 +276,10 @@
             var h = {};
 
             for (var i = 0, l = a.length; i < l; i++) {
-              var key = JSON.stringify(a[i]);
+              var key = a[i];
+              if (typeof key !== 'number' && key !== null && key !== undefined && typeof key !== 'boolean') {
+                key = JSON.stringify(key);
+              }
               if (h[key]) return false;
               h[key] = true;
             }


### PR DESCRIPTION
...on the array `[3, "3"]` -- JSON.stringify was incorrectly causing `"3"` and `3` to be seen as duplicates. Also added cases for truthy and falsy values to make sure that `[null, 0, false, undefined, 1, true]` didn't give a false positive either.
