### PR TITLE
Format Extensions not being picked up by default

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -205,7 +205,7 @@
     if (schema.format && options.validateFormats) {
       format = schema.format;
 
-      if (options.formatExtensions) { spec = validate.formatExtensions[format] }
+      if (options.validateFormatExtensions) { spec = validate.formatExtensions[format] }
       if (!spec) {
         spec = validate.formats[format];
         if (options.validateFormatsStrict) {

--- a/test/validator-test.js
+++ b/test/validator-test.js
@@ -94,6 +94,7 @@ vows.describe('revalidator', {
     "with <maximum>":         assertValidates ( 512,      1949,      { maximum:   678 }),
     "with <divisibleBy>":     assertValidates ( 10,       9,         { divisibleBy: 5 }),
     "with <enum>":            assertValidates ("orange",  "cigar",   { enum: ["orange", "apple", "pear"] }),
+    "with <format>:'url'":    assertValidates ('http://test.com/', 'hello', { format: 'url' }),
     "with <dependencies>": {
       topic: {
         properties: {


### PR DESCRIPTION
Defaults list the option setting as `validateFormatExtensions` but the code referenced `formatExtensions`.  Added test for url format, and tweaked the code.
