### PR TITLE
change to reflect messages in scheme

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -244,6 +244,8 @@
     checkType(value, schema.type, function(err, type) {
       if (err) return error('type', property, typeof value, schema, errors);
 
+      constrain('conform', value, function(e, a){return a(e)})
+
       switch (type || (isArray(value) ? 'array' : typeof value)) {
         case 'string':
           constrain('minLength', value.length, function (a, e) { return a >= e });
@@ -321,7 +323,7 @@
   };
 
   function error(attribute, property, actual, schema, errors) {
-    var message = (schema.message || validate.messages && validate.messages[attribute]) || "no default message";
+    var message = (validate.messages && validate.messages[attribute] || schema.message ) || "no default message";
     errors.push({
       attribute: attribute,
       property:  property,


### PR DESCRIPTION
change to reflect messages in scheme.

when you give:

```
var schema = {
  properties:{
    name: {
      type: 'string',
      required: true,
      message: 'your name is required'
    }
  }
}
```

Then you get as a result of validation:

```
{ valid: false,
  errors: 
   [ { attribute: 'required',
       property: 'name',
       expected: true,
       actual: undefined,
       message: 'your name is required } ] }
```
