### PR TITLE
default and custom error messages support

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -83,14 +83,19 @@
    * Default messages to include with validation errors.
    */
   validate.messages = {
-      required:  "",
-      pattern:   "",
-      maximum:   "",
-      minimum:   "",
-      maxLength: "",
-      minLength: "",
-      dependencies:  "",
-      unique:    ""
+      required:         "is required",
+      minLength:        "is too short (minimum is %{expected} characters)",
+      maxLength:        "is too long (maximum is %{expected} characters)",
+      pattern:          "invalid input",
+      minimum:          "must be greater than or equal to %{expected}",
+      maximum:          "must be less than or equal to %{expected}",
+      exclusiveMinimum: "must be greater than %{expected}",
+      exclusiveMaximum: "must be less than %{expected}",
+      divisibleBy:      "must be divisible by %{expected}",
+      minItems:         "must contain more than %{expected} items",
+      maxItems:         "must contain less than %{expected} items",
+      uniqueItems:      "must hold a unique set of values",
+      format:           "is not a valid %{expected}"
   };
 
   /**
@@ -321,7 +326,9 @@
   };
 
   function error(attribute, property, actual, schema, errors) {
-    var message = validate.messages && validate.messages[property] || "no default message";
+    var lookup = { expected: schema[attribute], attribute: attribute, property: property };
+    var message = schema.messages && schema.messages[attribute] || validate.messages[attribute] || "no default message";
+    message = message.replace(/%\{([a-z]+)\}/ig, function (_, match) { return lookup[match.toLowerCase()] || ''; }); 
     errors.push({
       attribute: attribute,
       property:  property,

--- a/test/validator-test.js
+++ b/test/validator-test.js
@@ -29,6 +29,15 @@ function assertHasError(attr, field) {
   };
 }
 
+function assertHasErrorMsg(attr, msg) {
+  return function (res) {
+    assert.notEqual(res.errors.length, 0);
+    assert.ok(res.errors.some(function (e) {
+      return e.attribute === attr && e.message === msg;
+    }));
+  };
+}
+
 function assertValidates(passingValue, failingValue, attributes) {
   var schema = {
     name: 'Resource',
@@ -173,7 +182,7 @@ vows.describe('revalidator', {
             }
           }
         },
-        date: { type: 'string', format: 'date' },
+        date: { type: 'string', format: 'date', messages: { format: "must be a valid %{expected} and nothing else" } },
         body: { type: 'string' },
         tags: {
           type: 'array',
@@ -184,7 +193,7 @@ vows.describe('revalidator', {
             pattern: /[a-z ]+/
           }
         },
-        author:    { type: 'string', pattern: /^[\w ]+$/i, required: true},
+        author:    { type: 'string', pattern: /^[\w ]+$/i, required: true, messages: { required: "is essential for survival" } },
         published: { type: 'boolean', 'default': false },
         category:  { type: 'string' }
       },
@@ -223,7 +232,8 @@ vows.describe('revalidator', {
             return revalidator.validate(object, schema);
           },
           "return an object with `valid` set to false":       assertInvalid,
-          "and an error concerning the 'required' attribute": assertHasError('required')
+          "and an error concerning the 'required' attribute": assertHasError('required'),
+          "and the error message defined":                    assertHasErrorMsg('required', "is essential for survival")
         },
         "and if it has a missing non-required property": {
           topic: function (object, schema) {
@@ -271,7 +281,8 @@ vows.describe('revalidator', {
             object.date = 'bad date';
             return revalidator.validate(object, schema);
           },
-          "return an object with `valid` set to false":       assertInvalid
+          "return an object with `valid` set to false":       assertInvalid,
+          "and the error message defined":                    assertHasErrorMsg('format', "must be a valid date and nothing else")
         },
         "and if it didn't validate a pattern": {
           topic: function (object, schema) {


### PR DESCRIPTION
I've defined in the default error messages and implemented a way to define custom ones.

If a message is just a string, it is used unchanged as the error message.
If it's of type array it will be used as follows:
`array[0]` `property.value` `array[1..n].join(' ')`

e.g.:
`title: { maxLength: 140 }` with format message: `["is too long (maximum is", "characters)"]` will lead to _is too long (maximum is 140 characters)_ 

Custom messages could be defined as follows:

```
properties: {
  email: {
    required: true,
    format: 'email',
    messages: {
      required: "is required",
      format: ["is not a valid"]
    }
  }
}
```
