### PR TITLE
Add support for additionalProperties per 5.4

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -156,13 +156,16 @@
   };
 
   function validateObject(object, schema, options, errors) {
-    var props;
+    var props
+      , allProps = Object.keys(object)
+      , visitedProps = [];
 
     // see 5.2
     if (schema.properties) {
       props = schema.properties;
       for (var p in props) {
         if (props.hasOwnProperty(p)) {
+          visitedProps.push(p);
           validateProperty(object, object[p], p, props[p], options, errors);
         }
       }
@@ -177,10 +180,35 @@
 
           // Find all object properties that are matching `re`
           for (var k in object) {
-            if (object.hasOwnProperty(k) && re.exec(k) !== null) {
-              validateProperty(object, object[k], p, props[p], options, errors);
+            if (object.hasOwnProperty(k)) {
+              visitedProps.push(k);
+              if (re.exec(k) !== null) {
+                validateProperty(object, object[k], p, props[p], options, errors);
+              }
             }
           }
+        }
+      }
+    }
+    
+    // see 5.4
+    if (schema.additionalProperties) {
+      var i, l;
+      
+      var unvisitedProps = allProps.filter(function(k){
+        return (visitedProps.indexOf(k) > 0);
+      });
+      
+      // Prevent additional properties; each unvisited property is therefore an error
+      if (schema.additionalProperties === false && unvisitedProps.length > 0) {
+        for (i = 0, l = unvisitedProps.length; i < l; i++) {
+          error("additionalProperties", unvisitedProps[i], object[unvisitedProps[i]], false, errors);
+        }
+      }
+      // additionalProperties is a schema and validate unvisited properties against that schema
+      else if (typeof schema.additionalProperties == "object" && unvisitedProps.length > 0) {
+        for (i = 0, l = unvisitedProps.length; i < l; i++) {
+          validateProperty(object, object[unvisitedProps[i]], unvisitedProps[i], schema.unvisitedProperties, options, errors);
         }
       }
     }
@@ -296,7 +324,7 @@
           break;
         case 'object':
           // Recursive validation
-          if (schema.properties || schema.patternProperties) {
+          if (schema.properties || schema.patternProperties || schema.additionalProperties) {
             validateObject(value, schema, options, errors);
           }
           break;


### PR DESCRIPTION
Added support to revalidator for section 5.4 of the draft (v3). 'additionalProperties' can be:
1. `false` to raise an error for each property that is not defined/matched under either 'properties' or 'patternProperties'; or
2. a schema in which case all properties that are not defined/matched under either 'properties' or 'patternProperties' must conform to the schema.
