### PR TITLE
Remove usage of the reserved word 'enum'

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -224,7 +224,7 @@
       }
     }
 
-    if (schema.enum && schema.enum.indexOf(value) === -1) {
+    if (schema['enum'] && schema['enum'].indexOf(value) === -1) {
       error('enum', property, value, schema, errors);
     }
 


### PR DESCRIPTION
revalidator.js does not currently load in Internet Explorer < 9. 

The offending code is :

``` js
if (schema.enum && schema.enum.indexOf(value) === -1) {
```

which fails because enum is a reserved word. See  https://developer.mozilla.org/en/JavaScript/Reference/Reserved_Words
