### PR TITLE
Changed Object.keys to _.keys to support IE8

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -1,4 +1,4 @@
-(function (exports) {
+(function (exports, _) {
   exports.validate = validate;
   exports.mixin = mixin;
 
@@ -159,7 +159,7 @@
   };
 
   function validateObject(object, schema, options, errors) {
-    var props, allProps = Object.keys(object),
+    var props, allProps = _.keys(object),
         visitedProps = [];
 
     // see 5.2
@@ -406,4 +406,4 @@
   }
 
 
-})(typeof(window) === 'undefined' ? module.exports : (window.json = window.json || {}));
+})(typeof(window) === 'undefined' ? module.exports : (window.json = window.json || {}), typeof(window) === 'undefined' ? require('underscore') : _ );

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "type": "git",
     "url": "http://github.com/flatiron/revalidator.git"
   },
+  "dependencies": {
+    "underscore": "1.4.3"
+  },
   "devDependencies": {
     "vows": "0.6.x"
   },


### PR DESCRIPTION
IE 8 does not support Object.keys. 
This change requires underscore.js to be loaded into the browser
