### PR TITLE
fix enum validation type 'array', add path to error for nested props, fix cast for the case when 'type' is an array

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -238,7 +238,11 @@
           validateObject({}, schema, options, errors, (!path ? property : path) + ".");
         }
         else if(schema.items && schema.items.properties){
-          validateObject({}, schema.items, options, errors, (!path ? property : path) + "[0].");
+          checkType([], schema.type, function(err, type){
+            if(!err && type=='array'){
+              validateObject({}, schema.items, options, errors, (!path ? property : path) + "[0].");
+            }
+          });
         }
         return;
       } else {


### PR DESCRIPTION
fix a few issues:

fix enum validation when attribute is of type 'array'
before the fix indexOf was used to compare the whole value of the field but since the value is an array ['item1', 'item2'], it would end  up looking for the whole piece ['item1', 'item2'] instead of examing each item in the value array.

add path to error object for nested properties, so that the name of the property contains the parent name and its property name

fix cast for the case when 'type' is an array; change string comparison to indexOf search that works both for strings and arrays
