### PR TITLE
Passing current object to conform function

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -295,7 +295,7 @@
     checkType(value, schema.type, function(err, type) {
       if (err) return error('type', property, typeof value, schema, errors);
 
-      constrain('conform', value, function (a, e) { return e(a) });
+      constrain('conform', value, function (a, e) { return e(a, object) });
 
       switch (type || (isArray(value) ? 'array' : typeof value)) {
         case 'string':


### PR DESCRIPTION
I patched revalidator to pass the current object to the conform method to add the ability to do deeper contextual validations.

Example: My schema has a start date and an end date. 

```
  startDate: {
    type: 'string',
    format: 'date',
    required: true
  },
  endDate: {
    type: 'string',
    format: 'date',
    dependencies: 'startDate',
    required: true,
    conform: function(v, o) {
      var startDate = new Date(o.startDate);
      var endDate = new Date(o.endDate);

      if(endDate - startDate < 0)
        return false;
      else
        return true;
    },
    messages: {
      conform: 'end date must be after start date'
    }
  }
```

This allows me to parse the end date and start date and make sure end date is after start date.

Hope this gets pulled in. Great work on the validator!

-Marshall
