### PR TITLE
Make 'actual' available to custom error messages

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -379,7 +379,7 @@
   };
 
   function error(attribute, property, actual, schema, errors) {
-    var lookup = { expected: schema[attribute], attribute: attribute, property: property };
+    var lookup = { expected: schema[attribute], actual: actual, attribute: attribute, property: property };
     var message = schema.messages && schema.messages[attribute] || schema.message || validate.messages[attribute] || "no default message";
     message = message.replace(/%\{([a-z]+)\}/ig, function (_, match) { return lookup[match.toLowerCase()] || ''; });
     errors.push({


### PR DESCRIPTION
Not having the actual value available in the error message seems like an oversight.
