### PR TITLE
Fix cast option.

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -240,15 +240,18 @@
     if (options.cast) {
       if (('integer' === schema.type || 'number' === schema.type) && value == +value) {
         value = +value;
+        object[property] = value;
       }
 
       if ('boolean' === schema.type) {
         if ('true' === value || '1' === value || 1 === value) {
           value = true;
+          object[property] = value;
         }
 
         if ('false' === value || '0' === value || 0 === value) {
           value = false;
+          object[property] = value;
         }
       }
     }

--- a/test/validator-test.js
+++ b/test/validator-test.js
@@ -360,6 +360,14 @@ vows.describe('revalidator', {
             return revalidator.validate({ answer: "forty2" }, schema, { cast: true });
           },
           "return an object with `valid` set to false": assertInvalid
+        },
+        "is casted to integer": {
+          topic: function (schema) {
+            var object = { answer: "42" };
+            revalidator.validate(object, schema, { cast: true });
+            return object;
+          },
+          "return an object with `answer` set to 42": function(res) { assert.strictEqual(res.answer, 42) }
         }
       },
       "and <boolean> property": {
@@ -392,6 +400,14 @@ vows.describe('revalidator', {
             return revalidator.validate({ is_ready: 42 }, schema, { cast: true });
           },
           "return an object with `valid` set to false": assertInvalid
+        },
+        "is casted to boolean": {
+          topic: function (schema) {
+            var object = { is_ready: "true" };
+            revalidator.validate(object, schema, { cast: true });
+            return object;
+          },
+          "return an object with `is_ready` set to true": function(res) { assert.strictEqual(res.is_ready, true) }
         }
       }
     }


### PR DESCRIPTION
The cast option is used mostly on a server side with `GET` requests. `GET` request converts everything to strings, and the casting helps to repair types back. This patch fixes the previous implementation, that leaves the original object unchanged.
