### PR TITLE
Update the exports line to work in node.js, browser and browserify

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -406,4 +406,4 @@
   }
 
 
-})(module.exports);
+})(typeof module === 'object' && module && module.exports ? module.exports : window);


### PR DESCRIPTION
Currently revalidtor can't be ported to the browser through browserify, because it checks for the existence of window.
For context on this change see: https://github.com/substack/node-browserify/issues/293

Also makes the validate function available in window instead of window.json (inline with the documentation). See: https://github.com/flatiron/revalidator/issues/30
