### PR TITLE
Alternative check for Node.js context.

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -406,4 +406,4 @@
   }
 
 
-})(typeof(window) === 'undefined' ? module.exports : (window.json = window.json || {}));
+})(typeof(module) !== undefined && module.exports !== undefined ? module.exports : (window.json = window.json || {}));


### PR DESCRIPTION
A stray global `window` variable was causing revalidator to be unusable as a module.
