### PR TITLE
revert #53 to fix empty string usecase and add allowEmpty to fix #53

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,17 @@ This will return with a value indicating if the `obj` conforms to the `schema`. 
 For a property an `value` is that which is given as input for validation where as an `expected value` is the value of the below fields
 
 #### required
-If true, the value should not be empty
+If true, the value should not be undefined
 
 ```js
 { required: true }
+```
+
+#### allowEmpty
+If false, the value must not be an empty string
+
+```js
+{ allowEmpty: false }
 ```
 
 #### type

--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -84,6 +84,7 @@
    */
   validate.messages = {
       required:         "is required",
+      allowEmpty:       "must not be empty",
       minLength:        "is too short (minimum is %{expected} characters)",
       maxLength:        "is too long (maximum is %{expected} characters)",
       pattern:          "invalid input",
@@ -229,7 +230,7 @@
       }
     }
 
-    if (value === undefined || value === '') {
+    if (value === undefined) {
       if (schema.required && schema.type !== 'any') {
         return error('required', property, undefined, schema, errors);
       } else {
@@ -299,9 +300,10 @@
 
       switch (type || (isArray(value) ? 'array' : typeof value)) {
         case 'string':
-          constrain('minLength', value.length, function (a, e) { return a >= e });
-          constrain('maxLength', value.length, function (a, e) { return a <= e });
-          constrain('pattern',   value,        function (a, e) {
+          constrain('allowEmpty', value,        function (a, e) { return e ? e : a !== '' });
+          constrain('minLength',  value.length, function (a, e) { return a >= e });
+          constrain('maxLength',  value.length, function (a, e) { return a <= e });
+          constrain('pattern',    value,        function (a, e) {
             e = typeof e === 'string'
               ? e = new RegExp(e)
               : e;

--- a/test/validator-test.js
+++ b/test/validator-test.js
@@ -94,6 +94,7 @@ vows.describe('revalidator', {
     "with <pattern>":             assertValidates ("kaboom", "42",       { pattern: /^[a-z]+$/ }),
     "with <maxLength>":           assertValidates ("boom",   "kaboom",   { maxLength: 4 }),
     "with <minLength>":           assertValidates ("kaboom", "boom",     { minLength: 6 }),
+    "with <allowEmpty>":          assertValidates ("hello",  "",         { allowEmpty: false }),
     "with <minimum>":             assertValidates ( 512,      43,        { minimum:   473 }),
     "with <maximum>":             assertValidates ( 512,      1949,      { maximum:   678 }),
     "with <divisibleBy>":         assertValidates ( 10,       9,         { divisibleBy: 5 }),


### PR DESCRIPTION
#53 changed behaviour of `required` so that an empty string wasn't acceptable which was in contra to advice in #32.

Resolve #53 by adding allowEmpty property which checks for empty strings.
