### PR TITLE
add message for additionalProperties

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -97,7 +97,8 @@
       uniqueItems:      "must hold a unique set of values",
       format:           "is not a valid %{expected}",
       conform:          "must conform to given constraint",
-      type:             "must be of %{expected} type"
+      type:             "must be of %{expected} type",
+      additionalProperties: "must not exist"
   };
   validate.messages['enum'] = "must be present in given enumerator";
 


### PR DESCRIPTION
the PR previously known as #51 makes a comeback

When validation fails because `additionalProperties: false` and there's an extraneous property it displays a generic message "no default message".  This adds a message for additionalProperties that reads  "must not exist".
