### PR TITLE
Fix inconsistent headers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Value must be greater than expected value
 { exclusiveMinimum: 9 }
 ```
 
-### exclusiveMaximum
+#### exclusiveMaximum
 Value must be lesser than expected value
 
 ```js


### PR DESCRIPTION
Please excuse me if this was intentional, but it seems strange that all the properties in the docs about `Schema` uses h4 tags, except for one. 

So this very minor pull request fixes that.

Thanks for an awesome module by the way!
