### PR TITLE
patternProperties not subjected to additionalProperties constraint

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -185,7 +185,7 @@
           for (var k in object) {
             if (object.hasOwnProperty(k)) {
               if (re.exec(k) !== null) {
-                validateProperty(object, object[k], p, props[p], options, errors);
+                validateProperty(object, object[k], k, props[p], options, errors);
                 visitedProps.push(k);
               }
             }


### PR DESCRIPTION
Currently, there is a bug with patternProperties where if a property is not visited, it is counted as visited, even if not matched to a regular expression.

This fix subjects all unvisited properties, including those not matched to a patternProperty regular expression, to the additionalProperties constraint.
