### PR TITLE
use Math.floor instead of ~~ for integer

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -372,7 +372,7 @@
           type === 'object' ? val && typeof val === 'object' &&
                              !isArray(val) :
           type === 'number' ? typeof val === 'number' :
-          type === 'integer' ? typeof val === 'number' && ~~val === val :
+          type === 'integer' ? typeof val === 'number' && Math.floor(val) === val :
           type === 'null' ? val === null :
           type === 'boolean'? typeof val === 'boolean' :
           type === 'date' ? isDate(val) :

--- a/test/validator-test.js
+++ b/test/validator-test.js
@@ -83,6 +83,7 @@ vows.describe('revalidator', {
     "with <type>:'string'":       assertValidates ('hello',   42,        { type: "string" }),
     "with <type>:'number'":       assertValidates (42,       'hello',    { type: "number" }),
     "with <type>:'integer'":      assertValidates (42,        42.5,      { type: "integer" }),
+    "with <type>:'integer'":      assertValidates (10000000000, 10000000000.5,      { type: "integer" }),
     "with <type>:'array'":        assertValidates ([4, 2],   'hi',       { type: "array" }),
     "with <type>:'object'":       assertValidates ({},        [],        { type: "object" }),
     "with <type>:'boolean'":      assertValidates (false,     42,        { type: "boolean" }),


### PR DESCRIPTION
When testing large numbers, ~~ gives results that are inconsistent with Math.floor(). The performance impact is [_very_ small](http://jsperf.com/tilde-vs-floor).

I'm not quite familiar with revalidator's test suite, so please let me know if the test I've added belongs elsewhere.
