### PR TITLE
Fix a behavior when uniqueItems is false for array

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -334,7 +334,9 @@
           });
           constrain('minItems', value, function (a, e) { return a.length >= e });
           constrain('maxItems', value, function (a, e) { return a.length <= e });
-          constrain('uniqueItems', value, function (a) {
+          constrain('uniqueItems', value, function (a, e) {
+            if (!e) return true;
+
             var h = {};
 
             for (var i = 0, l = a.length; i < l; i++) {

--- a/test/validator-test.js
+++ b/test/validator-test.js
@@ -303,6 +303,16 @@ vows.describe('revalidator', {
           },
           "return an object with `valid` set to false":       assertInvalid
         },
+        "and if it has a correct array property (uniqueItems false)": {
+          topic: function (object, schema) {
+            object = clone(object);
+            schema = clone(schema);
+            schema.properties.tags.uniqueItems = false;
+            object.tags = ['a', 'a'];
+            return revalidator.validate(object, schema);
+          },
+          "return an object with `valid` set to false":       assertValid
+        },
         "and if it has a incorrect array property (wrong values)": {
           topic: function (object, schema) {
             object = clone(object);


### PR DESCRIPTION
If uniqueItems is specified as false, it works as the same as 'uniqueItems: true'.
