### PR TITLE
Fix casting of empty strings to integers

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -257,7 +257,7 @@
     }
 
     if (options.cast) {
-      if (('integer' === schema.type || 'number' === schema.type) && value == +value) {
+      if (('integer' === schema.type || 'number' === schema.type) && value != "" && value == +value) {
         value = +value;
         object[property] = value;
       }

--- a/test/validator-test.js
+++ b/test/validator-test.js
@@ -715,6 +715,12 @@ vows.describe('revalidator', {
           },
           "return an object with `valid` set to false": assertInvalid
         },
+        "is empty string": {
+          topic: function (schema) {
+            return revalidator.validate({ answer: "" }, schema, { cast: true });
+          },
+          "return an object with `valid` set to false": assertInvalid
+        },
         "is casted to integer": {
           topic: function (schema) {
             var object = { answer: "42" };


### PR DESCRIPTION
Before this patch if you cast an empty string to an integer it would not error on the field. (even with `allowEmpty: false`) . I'm not sure what the expected error message should be, but I suspect that it shouldn't be considered valid.
