### PR TITLE
Update README to include conform example with obj

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,15 @@ Value must conform to constraint denoted by expected value
 }
 ```
 
+`conform` is also passed the object that is being validated
+
+```js
+{ conform: function (passwordConfirmation, obj) {
+    return passwordConfirmation == obj.password;
+  }
+}
+```
+
 #### dependencies
 Value is valid only if the dependent value is valid
 


### PR DESCRIPTION
The documentation doesn't explicitly show that the object that is being validated is also passed to the `conform` function. We wanted this behavior for password confirmation, and had to go digging through the source to figure out that it worked this way.
