### PR TITLE
Fix crash when 'additionalProperties' is a schema

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -229,7 +229,7 @@
       // additionalProperties is a schema and validate unvisited properties against that schema
       else if (typeof schema.additionalProperties == "object" && unvisitedProps.length > 0) {
         for (i = 0, l = unvisitedProps.length; i < l; i++) {
-          validateProperty(object, object[unvisitedProps[i]], unvisitedProps[i], schema.unvisitedProperties, options, errors);
+          validateProperty(object, object[unvisitedProps[i]], unvisitedProps[i], schema.additionalProperties, options, errors);
         }
       }
     }


### PR DESCRIPTION
To fix the following bug

```
[richard@tigger blah]$ cat blah.js 
var revalidator = require('revalidator')
var object = { 
    foo: 'bar'
}

var schema = { 
    properties: { 
        "baz": { 
            type: 'string',
            required: true
        }
    },
    additionalProperties: 
    {
        type: 'string',
        description: 'This will crash revalidator' 
    },
    type: 'object' }

return revalidator.validate(object, schema)
[richard@tigger blah]$ node blah.js

/home/richard/blah/node_modules/revalidator/lib/revalidator.js:278
    if (schema.format && options.validateFormats) {
              ^
TypeError: Cannot read property 'format' of undefined
    at validateProperty (/home/richard/blah/node_modules/revalidator/lib/revalidator.js:278:15)
    at validateObject (/home/richard/blah/node_modules/revalidator/lib/revalidator.js:232:11)
    at Object.validate (/home/richard/blah/node_modules/revalidator/lib/revalidator.js:35:7)
    at Object.<anonymous> (/home/richard/blah/blah.js:20:20)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
```
