### PR TITLE
Fix for #105, with test

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -229,7 +229,7 @@
       // additionalProperties is a schema and validate unvisited properties against that schema
       else if (typeof schema.additionalProperties == "object" && unvisitedProps.length > 0) {
         for (i = 0, l = unvisitedProps.length; i < l; i++) {
-          validateProperty(object, object[unvisitedProps[i]], unvisitedProps[i], schema.unvisitedProperties, options, errors);
+          validateProperty(object, object[unvisitedProps[i]], unvisitedProps[i], schema.additionalProperties, options, errors);
         }
       }
     }

--- a/test/validator-test.js
+++ b/test/validator-test.js
@@ -211,6 +211,22 @@ vows.describe('revalidator', {
         "return an object with `valid` set to false": assertInvalid
       }
     },
+    "with <additionalProperties>:schema": {
+      topic: {
+        properties: {
+          town: { type: 'string' }
+        },
+        additionalProperties: {
+          properties: { type: 'string' }
+        }
+      },
+      "when the object conforms": {
+        topic: function (schema) {
+          return revalidator.validate({ town: "luna", area: "park"}, schema);
+        },
+        "return an object with `valid` set to true": assertValid
+      }
+    },
     "with option <additionalProperties>:false": {
       topic: {
         properties: {


### PR DESCRIPTION
When additionalProperties is present, but not falsy, validation throws an error. The problem is just that the array of unvisited property names is passed to validateProperty instead of the schema. Easy fix.
