### PR TITLE
Changed the execution order of validations - conform, format, enum

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -373,6 +373,9 @@
             });
             nestedErrors.unshift(0, 0);
             Array.prototype.splice.apply(errors, nestedErrors);
+
+            constrain('minItems', value, function (a, e) { return Object.keys(a).length >= e });
+            constrain('maxItems', value, function (a, e) { return Object.keys(a).length <= e });
           }
           break;
       }

--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -275,27 +275,6 @@
       }
     }
 
-    if (schema.format && options.validateFormats) {
-      format = schema.format;
-
-      if (options.validateFormatExtensions) { spec = validate.formatExtensions[format] }
-      if (!spec) { spec = validate.formats[format] }
-      if (!spec) {
-        if (options.validateFormatsStrict) {
-          return error('format', property, value, schema, errors);
-        }
-      }
-      else {
-        if (!spec.test(value)) {
-          return error('format', property, value, schema, errors);
-        }
-      }
-    }
-
-    if (schema['enum'] && schema['enum'].indexOf(value) === -1) {
-      error('enum', property, value, schema, errors);
-    }
-
     // Dependencies (see 5.8)
     if (typeof schema.dependencies === 'string' &&
         object[schema.dependencies] === undefined) {
@@ -316,8 +295,6 @@
 
     checkType(value, schema.type, function(err, type) {
       if (err) return error('type', property, typeof value, schema, errors);
-
-      constrain('conform', value, function (a, e) { return e(a, object) });
 
       switch (type || (isArray(value) ? 'array' : typeof value)) {
         case 'string':
@@ -389,7 +366,30 @@
           }
           break;
       }
+
+      constrain('conform', value, function (a, e) { return e(a, object) });
     });
+
+    if (schema.format && options.validateFormats) {
+      format = schema.format;
+
+      if (options.validateFormatExtensions) { spec = validate.formatExtensions[format] }
+      if (!spec) { spec = validate.formats[format] }
+      if (!spec) {
+        if (options.validateFormatsStrict) {
+          return error('format', property, value, schema, errors);
+        }
+      }
+      else {
+        if (!spec.test(value)) {
+          return error('format', property, value, schema, errors);
+        }
+      }
+    }
+
+    if (schema['enum'] && schema['enum'].indexOf(value) === -1) {
+      error('enum', property, value, schema, errors);
+    }
   }
 
   function checkType(val, type, callback) {

--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -325,7 +325,12 @@
             var nestedErrors;
             for (var i = 0, l = a.length; i < l; i++) {
               nestedErrors = [];
-              validateProperty(object, a[i], property, e, options, nestedErrors);
+              var newE = e;
+              if (typeof e === 'function') {
+                newE = e(a[i]);
+              }
+
+              validateProperty(object, a[i], property, newE, options, nestedErrors);
               nestedErrors.forEach(function (err) {
                 err.property =
                   (property ? property + '.' : '') +

--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -249,7 +249,12 @@
     }
 
     if (value === undefined) {
-      if (schema.required && schema.type !== 'any') {
+      var isRequired = schema.required;
+      if (typeof isRequired === 'function') {
+        isRequired = isRequired.bind(object)();
+      }
+
+      if (isRequired && schema.type !== 'any') {
         return error('required', property, undefined, schema, errors);
       } else {
         return;

--- a/test/validator-test.js
+++ b/test/validator-test.js
@@ -530,6 +530,7 @@ vows.describe('revalidator', {
         },
         publisher: {
           type: 'object',
+          minItems: 2,
           properties: {
             name: { type: 'string' },
             agents: {
@@ -629,6 +630,14 @@ vows.describe('revalidator', {
           topic: function (object, schema) {
             object = clone(object);
             object._additionalFlag = 'text';
+            return revalidator.validate(object, schema);
+          },
+          "return an object with `valid` set to false":       assertInvalid
+        },
+        "and if it has a incorrect property (< minItems)": {
+          topic: function (object, schema) {
+            object = clone(object);
+            delete object.publisher.name;
             return revalidator.validate(object, schema);
           },
           "return an object with `valid` set to false":       assertInvalid


### PR DESCRIPTION
Really appreciate your hard work on this module!

I heavily use `conform`, `enum`, `format`. And the current order of validation was causing me to write a lot of extra validations again and again.

There were cases where I used `conform` (and sometimes `format`) but first needed to check the length of the string. I had to write those validations manually in `conform`. So I decided to move `conform`, `format`, `enum` after `string`, `number`, etc validations.

Same goes for `enums`.
