### PR TITLE
Adding date type in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The `type of value` should be equal to the expected value
 { type: 'number' }
 { type: 'integer' }
 { type: 'array' }
+{ type: 'date' }
 { type: 'boolean' }
 { type: 'object' }
 { type: 'null' }


### PR DESCRIPTION
Would be interesting to update the README to ensure that all available types appear properly.

Date type was added in #59

Fix #73 