### PR TITLE
Ensure value is string before validating format

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -275,7 +275,7 @@
       }
     }
 
-    if (schema.format && options.validateFormats) {
+    if (schema.format && options.validateFormats && typeof value === 'string') {
       format = schema.format;
 
       if (options.validateFormatExtensions) { spec = validate.formatExtensions[format] }


### PR DESCRIPTION
Format validation can only be applied to string objects. Checking the value is a string before validating the format means that format validation can be used when multiple types are accepted
e.g.
```js
{
  type: ['string', 'null'],
  format: 'date-time'
}
```